### PR TITLE
Use an optional parameter to clean up setAlarmMode() method.

### DIFF
--- a/devicetypes/ethayer/zwave-schlage-touchscreen-lock.src/zwave-schlage-touchscreen-lock.groovy
+++ b/devicetypes/ethayer/zwave-schlage-touchscreen-lock.src/zwave-schlage-touchscreen-lock.groovy
@@ -1315,7 +1315,6 @@ def setAlarmMode(def newValue = null)
 			case "Kick":
 				newMode = 0x3
 				break
-			case "unknown_alarmMode":
 			default:
 				// don't send a mode - instead request the current state
 				cmds = secureSequence([zwave.configurationV2.configurationGet(parameterNumber: 0x7)], 5000)


### PR DESCRIPTION
As promised, a little clean up by making the setAlarmMode take an optional parameter.