### PR TITLE
Do not use armDelay if keypad is armed as 'stay'

### DIFF
--- a/smartapps/ethayer/keypad.src/keypad.groovy
+++ b/smartapps/ethayer/keypad.src/keypad.groovy
@@ -176,7 +176,7 @@ def armCommand(value, correctUser, enteredCode) {
 
   // only delay on ARM actions
   def useDelay = 0
-  if (armMode != 'off') {
+  if (armMode != 'off' && armMode != 'stay') {
     useDelay = armDelay
   }
 


### PR DESCRIPTION
When at home and arming a keypad with 'stay' mode, I did not want the arm delay to be used.  This seems reasonable since the delay is unnecessary as one would be staying inside the home.