### PR TITLE
Changes for SHM Delay

### DIFF
--- a/smartapps/ethayer/keypad.src/keypad.groovy
+++ b/smartapps/ethayer/keypad.src/keypad.groovy
@@ -1,4 +1,5 @@
 /** 
+Sep 18, 2017 Eliminate use of Runin when useDelay seconds is zero. Improves reliability and performance.
 Aug 26, 2017 Comment out sendSHMEvent execution sends "night" alarm state and causes extraneous overhead
 Aug 26, 2017 In alarmStatusHandler on stay mode use Mode issue setArmedStay or setArmedNight
 Jul 16, 2017 Set ArmDelay only on Away mode
@@ -205,8 +206,10 @@ def armCommand(value, correctUser, enteredCode) {
     // set values for delayed event
     atomicState.codeEntered = enteredCode
     atomicState.armMode = armMode
-
-    runIn(useDelay, execRoutine)
+    if (useDelay>0)	
+    	{runIn(useDelay, execRoutine)}
+    else
+    	{execRoutine()}	
   }
 
   def message = "${keypad.label} was ${action} by ${correctUser.label}"

--- a/smartapps/ethayer/keypad.src/keypad.groovy
+++ b/smartapps/ethayer/keypad.src/keypad.groovy
@@ -1,3 +1,8 @@
+/** 
+Aug 26, 2017 Comment out sendSHMEvent execution sends "night" alarm state and causes extraneous overhead
+Aug 26, 2017 In alarmStatusHandler on stay mode use Mode issue setArmedStay or setArmedNight
+Jul 16, 2017 Set ArmDelay only on Away mode
+*/
 definition (
   name: 'Keypad',
   namespace: 'ethayer',
@@ -125,9 +130,14 @@ def alarmStatusHandler(event) {
   else if (runDefaultAlarm && event.value == 'away'){
     keypad?.setArmedAway()
   }
-  else if (runDefaultAlarm && event.value == 'stay') {
-    keypad?.setArmedStay()
-  }
+  else if (runDefaultAlarm && event.value == 'stay')
+  	{
+  	def theMode=location.currentMode;
+  	if (theMode=="Night")
+      		{keypad?.setArmedNight()}
+  	else
+    		{keypad?.setArmedStay()}
+  	}
 }
 
 def codeEntryHandler(evt) {
@@ -182,9 +192,11 @@ def armCommand(value, correctUser, enteredCode) {
 
   // only delay on ARM actions
   def useDelay = 0
-  if (armMode != 'off' && armMode != 'stay') {
-    useDelay = armDelay
-  }
+//if (armMode != 'off' && armMode != 'stay') {
+  if (armMode == 'away') //aab Jul 16, 2017 delay only on away, delay occurring on night armMode
+  	{
+  	useDelay = armDelay
+  	}
 
   if (useDelay > 0) {
     keypad.setExitDelay(useDelay)
@@ -208,7 +220,7 @@ def execRoutine() {
   def armMode = atomicState.armMode
   def userApp = parent.keypadMatchingUser(atomicState.codeEntered)
 
-  sendSHMEvent(armMode)
+//  sendSHMEvent(armMode)
 
   // run hello home actions
   if (armMode == 'away') {

--- a/smartapps/ethayer/keypad.src/keypad.groovy
+++ b/smartapps/ethayer/keypad.src/keypad.groovy
@@ -1,4 +1,5 @@
 /** 
+Oct 03, 2017 in routine alarmStatusHandler only issue setArmedNight for Xfinity 3400, not available on Iris
 Sep 19, 2017 Eliminate atomicState when passing data from of armCommand to execRoutine by passing a java map
 	     Attempt to handle rearming/disarming during exit delay by unscheduling any pending away tasks 		  		
 Sep 18, 2017 Eliminate use of Runin when useDelay seconds is zero to improve reliability and performance.
@@ -136,8 +137,8 @@ def alarmStatusHandler(event) {
   else if (runDefaultAlarm && event.value == 'stay')
   	{
   	def theMode=location.currentMode;
-  	if (theMode=="Night")
-      		{keypad?.setArmedNight()}
+  	if (theMode=="Night" && keypad?.getModelName()=="3400" && keypad?.getManufacturerName()=="CentraLite")
+      	{keypad?.setArmedNight()}
   	else
     		{keypad?.setArmedStay()}
   	}


### PR DESCRIPTION
Made three changes to Keypad module to improve performance with my SHMDelay SmartApp and correct it from setting an illegal AlarmState: Night. Some of my logic fails when it sees this AlarmState, and I'm not sure what SHM is doing with it. 

This version is needs some minor additional coding and documentation changes for general usage. I'm sending a Pull request to avoid any surprises and keep you informed of what I'm doing. The instructions for using my version of the Keypad module are included below.
 
I very much prefer to have a single version of this module and attempted to contact you with a private community message, but did not get a response. 
Thank you
Arn Burkhoff

**Keypad module replacement**
This is a forked version of E Thayer's module with the following changes:
Modification: Comment out sendSHMEvent. Kills setting default AlarmState before running user routines that also set the AlarmState and Mode. One of those AlarmStates is 'Night' which is not recognized by ST and my code.

Modification: When AlarmState is 'Stay' and Mode is 'Night' turns on the Keypad 'Sleep/Night' icon, otherwise lights the 'Stay/Standing Man' icon

Modification: Issue delay only in AlarmState: Away

Prior to installing this version you must define SHM Routines by going to
1. Automation->SmartApps->Lock Manager
2. Scroll down to Keypad Routines (Optional) These routines run for all defined keypads when a keypad AlarmState and valid pincode is entered, setting the SHM AlarmState.
Arm/Away : Goodbye
Disarm: I'm Back
Arm/Stay: Good Night
Arm/Night: Good Night
3. Remove these standard routines if they are coded on a Keypad Profile or User Profile to substantially reduce system overhead. 
4. Should you decide to use the “Way Beyond The Basics” we will revisit these settings

Source code is at repo arnbme lock-manager SHMDelay or directly at 
https://github.com/arnbme/lock-manager/blob/SHMDelay/smartapps/ethayer/keypad.src/keypad.groovy

To install with the SmartThings IDE go to SmartApps:
1. Click ''Settings' → Add new repository → enter: arnbme lock-manager SHMDelay->Save 
2. Click the edit icon to the left of the Keypad module name
3. Click 'Source Code Options' change to lock-manager (SHMDelay)->click Update on bottom of page
4. Click 'Update From Repo' → select lock-manager (SHMDelay)
5. Select 'Keypad'->leave 'publish' unchecked-> click 'Execute Update'

**Way beyond the basics for Xfinity and Centralite Keypads – getting Stay and Night icons and modes to function. (Not for use with Iris Keypads)**

1. Turn on True Night Mode (option to be released with next SHMDelay)
2. Implement Mode Fix option if there is the slightest chance you will set the AlarmState with the SmartThings - Dashboard Home or something that does not set Mode (option to be released with next SHMDelay)
3. Install my version of E Thayer's Lock Manager Keypad routine (see above)
4. In the IDE, My Locations, click the location, then create a new Mode “Stay”
5. Then in the phone app “Routines”, create a new routine named: Stay (or whatever you want). Set AlarmState to Stay, and Mode to Stay. Add other settings as desired
6. In the Lock Manager, Keypad Routines (Optional), set the newly created Stay routine name for Armed/Home.
7. Update the SHMDelay Mode Fix profile Stay options to include 'Stay' as a valid mode along with Night.  
8. Now when setting the alarm from the keypad, the Stay or Night icon is immediately lit. Stay uses an EntryDelay, Night creates an immediate intrusion.  Note: There is still a small delay lighting the Night icon when the AlarmState is changed with SmartThings - Dashboard Home  
