### PR TITLE
Add support for Yale Locks style of reporting codes

### DIFF
--- a/devicetypes/ethayer/zwave-lock-reporting.src/zwave-lock-reporting.groovy
+++ b/devicetypes/ethayer/zwave-lock-reporting.src/zwave-lock-reporting.groovy
@@ -199,8 +199,14 @@ def zwaveEvent(physicalgraph.zwave.commands.alarmv2.AlarmReport cmd) {
 				break
 			case 6:
 				if (cmd.eventParameter) {
-					map.descriptionText = "$device.displayName was unlocked with code ${cmd.eventParameter.first()}"
-					map.data = [ usedCode: cmd.eventParameter[0] ]
+					if (cmd.eventParameter.size() == 4) {
+						map.descriptionText = "$device.displayName was unlocked with code ${cmd.eventParameter[2]}"
+						map.data = [ usedCode: cmd.eventParameter[2] ]
+					}
+					else {
+						map.descriptionText = "$device.displayName was unlocked with code ${cmd.eventParameter.first()}"
+						map.data = [ usedCode: cmd.eventParameter[0] ]
+					}
 				}
 				break
 			case 9:


### PR DESCRIPTION
This let's Yale Locks report which code unlocked them. Otherwise it returns 99.