### PR TITLE
Update keypad.groovy

### DIFF
--- a/smartapps/ethayer/keypad.src/keypad.groovy
+++ b/smartapps/ethayer/keypad.src/keypad.groovy
@@ -38,6 +38,7 @@ def initialize() {
 
   if (keypad) {
     subscribe(location, 'alarmSystemStatus', alarmStatusHandler)
+    subscribe(location, 'securitySystemStatus', alarmStatusHandler)
     subscribe(keypad, 'codeEntered', codeEntryHandler)
   }
 }
@@ -122,12 +123,21 @@ def alarmStatusHandler(event) {
   if (runDefaultAlarm && event.value == 'off'){
     keypad?.setDisarmed()
   }
+  else if (runDefaultAlarm && event.value == 'disarmed'){
+    keypad?.setDisarmed()
+  }
   else if (runDefaultAlarm && event.value == 'away'){
+    keypad?.setArmedAway()
+  }
+  else if (runDefaultAlarm && event.value == 'armedAway'){
     keypad?.setArmedAway()
   }
   else if (runDefaultAlarm && event.value == 'stay') {
     keypad?.setArmedStay()
   }
+  else if (runDefaultAlarm && event.value == 'armedStay') {
+    keypad?.setArmedStay()
+  }  
 }
 
 def codeEntryHandler(evt) {

--- a/smartapps/ethayer/keypad.src/keypad.groovy
+++ b/smartapps/ethayer/keypad.src/keypad.groovy
@@ -102,6 +102,7 @@ def mainPage() {
     section('Routines') {
       paragraph 'settings here are for this keypad only. Global keypad settings, use parent app.'
       input(name: 'runDefaultAlarm', title: 'Act as SHM device?', type: 'bool', defaultValue: true, description: 'Toggle this off if actions should not effect SHM' )
+      input(name: 'runDefaultAlarm2', title: 'Act as ADT Keypad device?', type: 'bool', defaultValue: false, description: 'Toggle this off if your environment does not include a ADT Smartthings panel' )
       input(name: 'armRoutine', title: 'Arm/Away routine', type: 'enum', options: actions, required: false, multiple: true)
       input(name: 'disarmRoutine', title: 'Disarm routine', type: 'enum', options: actions, required: false, multiple: true)
       input(name: 'stayRoutine', title: 'Arm/Stay routine', type: 'enum', options: actions, required: false, multiple: true)
@@ -123,19 +124,19 @@ def alarmStatusHandler(event) {
   if (runDefaultAlarm && event.value == 'off'){
     keypad?.setDisarmed()
   }
-  else if (runDefaultAlarm && event.value == 'disarmed'){
+  else if (runDefaultAlarm2 && event.value == 'disarmed'){
     keypad?.setDisarmed()
   }
   else if (runDefaultAlarm && event.value == 'away'){
     keypad?.setArmedAway()
   }
-  else if (runDefaultAlarm && event.value == 'armedAway'){
+  else if (runDefaultAlarm2 && event.value == 'armedAway'){
     keypad?.setArmedAway()
   }
   else if (runDefaultAlarm && event.value == 'stay') {
     keypad?.setArmedStay()
   }
-  else if (runDefaultAlarm && event.value == 'armedStay') {
+  else if (runDefaultAlarm2 && event.value == 'armedStay') {
     keypad?.setArmedStay()
   }  
 }


### PR DESCRIPTION
This is a simple update to enable the  ADT Panel status on the Keypad device using Lock manager Keypad child app. 

No code was changes, or removed. This update simply allows the Keypad device to see the ADT Panel status change between Armed/Stay, Disarmed, and Armed/Away. This will enable users of Lockmanager to manage the ADT Panel with a Keypad Device when used in conjunction with ADT Tools 2 smartapp. 